### PR TITLE
6章分の追加

### DIFF
--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -21,4 +21,9 @@ public class TaskController {
         model.addAttribute("taskList", taskList);
         return "tasks/list";
     }
+
+    @GetMapping("/tasks/detail") // GET /tasks/detail
+    public String showDetail(){
+        return "tasks/detail";
+    }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 @Controller
 @RequiredArgsConstructor
@@ -22,8 +23,10 @@ public class TaskController {
         return "tasks/list";
     }
 
-    @GetMapping("/tasks/detail") // GET /tasks/detail
-    public String showDetail(){
+    @GetMapping("/tasks/{id}") // GET /tasks/detail
+    public String showDetail(@PathVariable("id") long taskId, Model model){
+        model.addAttribute("taskId", taskId);
+
         return "tasks/detail";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -25,8 +25,9 @@ public class TaskController {
 
     @GetMapping("/tasks/{id}") // GET /tasks/detail
     public String showDetail(@PathVariable("id") long taskId, Model model){
-        model.addAttribute("taskId", taskId);
-
+        var taskEntity = taskService.findById(taskId)
+                .orElseThrow(() -> new IllegalArgumentException("Task not found: id = " + taskId));
+        model.addAttribute("taskId", taskEntity.id());
         return "tasks/detail";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -27,7 +27,7 @@ public class TaskController {
     public String showDetail(@PathVariable("id") long taskId, Model model){
         var taskEntity = taskService.findById(taskId)
                 .orElseThrow(() -> new IllegalArgumentException("Task not found: id = " + taskId));
-        model.addAttribute("taskId", taskEntity.id());
+        model.addAttribute("task", TaskDTO.toDTO(taskEntity));
         return "tasks/detail";
     }
 }

--- a/src/main/java/com/example/todo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/todo/repository/task/TaskRepository.java
@@ -2,12 +2,17 @@ package com.example.todo.repository.task;
 
 import com.example.todo.service.task.TaskEntity;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
+import java.util.Optional;
 
 @Mapper
 public interface TaskRepository {
     @Select("SELECT id, summary, description, status FROM tasks;")
     List<TaskEntity> select();
+
+    @Select("SELECT id, summary, description, status FROM tasks WHERE id = #{taskId}")
+    Optional<TaskEntity> selectById(@Param("taskId") long taskId);
 }

--- a/src/main/java/com/example/todo/service/task/TaskService.java
+++ b/src/main/java/com/example/todo/service/task/TaskService.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -14,5 +15,9 @@ public class TaskService {
 
     public List<TaskEntity> find(){
         return taskRepository.select();
+    }
+
+    public Optional<TaskEntity> findById(long taskId) {
+        return taskRepository.selectById(taskId);
     }
 }

--- a/src/main/java/com/example/todo/service/task/TaskService.java
+++ b/src/main/java/com/example/todo/service/task/TaskService.java
@@ -10,7 +10,7 @@ import java.util.List;
 @RequiredArgsConstructor
 public class TaskService {
 
-    private  final TaskRepository taskRepository;
+    private final TaskRepository taskRepository;
 
     public List<TaskEntity> find(){
         return taskRepository.select();

--- a/src/main/resources/templates/tasks/detail.html
+++ b/src/main/resources/templates/tasks/detail.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="ja" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <title>タスク詳細</title>
+</head>
+<body>
+<h1>タスク詳細</h1>
+<a th:href="@{/tasks}">タスク一覧</a>
+</body>
+</html>

--- a/src/main/resources/templates/tasks/detail.html
+++ b/src/main/resources/templates/tasks/detail.html
@@ -7,5 +7,6 @@
 <body>
 <h1>タスク詳細</h1>
 <a th:href="@{/tasks}">タスク一覧</a>
+<p th:text="${taskId}"></p>
 </body>
 </html>

--- a/src/main/resources/templates/tasks/detail.html
+++ b/src/main/resources/templates/tasks/detail.html
@@ -7,6 +7,10 @@
 <body>
 <h1>タスク詳細</h1>
 <a th:href="@{/tasks}">タスク一覧</a>
-<p th:text="${taskId}"></p>
+<div th:object="${task}">
+    <h2 th:text="'#' + *{id} + ' ' + *{summary}"></h2>
+    <p th:text="*{status}"></p>
+    <pre th:text="*{description}"></pre>
+</div>
 </body>
 </html>

--- a/src/main/resources/templates/tasks/list.html
+++ b/src/main/resources/templates/tasks/list.html
@@ -19,8 +19,8 @@
         </thead>
         <tbody>
         <tr th:each="task : ${taskList}" th:object="${task}">
-            <td th:text="*{id}"></td>
-            <td th:text="*{summary}"></td>
+            <td><a th:href="@{/tasks/{id}(id=*{id})}" th:text="'#' + *{id}"></a></td>
+            <td><a th:href="@{/tasks/{id}(id=*{id})}" th:text="*{summary}"></a></td>
             <td th:text="*{status}"></td>
         </tr>
         </tbody>


### PR DESCRIPTION
- 46
    - タスク詳細画面のviewの作成
- 47
    - @PathVariableアノテーションの説明
    →URLから動的な値を簡単に取得でき、@GetMappingの引数を指定することでIDごとの画面制御ができるようになる
- 48
    - @PathVariableの実装、リクエストのURLに含まれている数値を取得し、画面に出力するように修正
- 49
    - コントローラから呼び出されるfindByIdメソッド（taskIdからtaskEntityを返す）をサービス層に記述
    - サービス層から呼び出されるselectByIdメソッド（taskIdからtaskEntityを返す）をリポジトリ層に記述
    →@SelectアノテーションでJavaから渡されたtaskIdに紐づく1件を取得するように記述
    - findByIdメソッドでコントローラに渡された戻り値がOptionalのため、orElseThrowメソッドでOptionalをはがすように記述
- 50
    - データベースからfindByIdメソッドで得た情報をタスク詳細画面にすべて表示させるように改修
- 51
    - タスク一覧画面からタスク詳細画面に遷移できるように改修
    - 