### PR TITLE
Feature springboot9

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@ repositories {
 
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
-//	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.2'
 	compileOnly 'org.projectlombok:lombok'

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -4,6 +4,8 @@ import com.example.todo.service.task.TaskService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.validation.BindingResult;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -42,7 +44,10 @@ public class TaskController {
     
     // POST /tasks
     @PostMapping
-    public String create(TaskForm form) {
+    public String create(@Validated TaskForm form, BindingResult bindingResult) {
+        if (bindingResult.hasErrors()) {
+            return "/tasks/form";
+        }
         taskService.create(form.toEntity());
         return "redirect:/tasks";
     }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -30,4 +30,10 @@ public class TaskController {
         model.addAttribute("task", TaskDTO.toDTO(taskEntity));
         return "tasks/detail";
     }
+
+    // GET /tasks/creationForm
+    @GetMapping("/tasks/creationForm")
+    public String showCreationForm() {
+        return "tasks/form";
+    }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -7,14 +7,16 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 @Controller
 @RequiredArgsConstructor
+@RequestMapping("/tasks")
 public class TaskController {
 
     private final TaskService taskService;
 
-    @GetMapping("/tasks")
+    @GetMapping
     public String list(Model model){
         var taskList = taskService.find() //List<TaskEntity> -> List<TaskDTO>
                 .stream()
@@ -24,7 +26,7 @@ public class TaskController {
         return "tasks/list";
     }
 
-    @GetMapping("/tasks/{id}") // GET /tasks/detail
+    @GetMapping("/{id}") // GET /tasks/detail
     public String showDetail(@PathVariable("id") long taskId, Model model){
         var taskEntity = taskService.findById(taskId)
                 .orElseThrow(() -> new IllegalArgumentException("Task not found: id = " + taskId));
@@ -33,13 +35,13 @@ public class TaskController {
     }
 
     // GET /tasks/creationForm
-    @GetMapping("/tasks/creationForm")
+    @GetMapping("/creationForm")
     public String showCreationForm() {
         return "tasks/form";
     }
     
     // POST /tasks
-    @PostMapping("/tasks")
+    @PostMapping
     public String create(TaskForm form) {
         taskService.create(form.toEntity());
         return "redirect:/tasks";

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -40,7 +40,7 @@ public class TaskController {
     
     // POST /tasks
     @PostMapping("/tasks")
-    public String create(Model model) {
+    public String create(TaskForm form, Model model) {
         return list(model);
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -1,8 +1,6 @@
 package com.example.todo.controller.task;
 
-import com.example.todo.service.task.TaskEntity;
 import com.example.todo.service.task.TaskService;
-import com.example.todo.service.task.TaskStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -43,8 +41,7 @@ public class TaskController {
     // POST /tasks
     @PostMapping("/tasks")
     public String create(TaskForm form) {
-        var newEntity = new TaskEntity(null, form.summary(), form.description(), TaskStatus.valueOf(form.status()));
-        taskService.create(newEntity);
+        taskService.create(form.toEntity());
         return "redirect:/tasks";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -38,15 +38,20 @@ public class TaskController {
 
     // GET /tasks/creationForm
     @GetMapping("/creationForm")
-    public String showCreationForm() {
+    public String showCreationForm(TaskForm form, Model model)
+    {
+        if (form == null){
+            form = new TaskForm(null, null, null);
+        }
+        model.addAttribute("taskForm", form);
         return "tasks/form";
     }
     
     // POST /tasks
     @PostMapping
-    public String create(@Validated TaskForm form, BindingResult bindingResult) {
+    public String create(@Validated TaskForm form, BindingResult bindingResult, Model model) {
         if (bindingResult.hasErrors()) {
-            return "/tasks/form";
+            return showCreationForm(form, model);
         }
         taskService.create(form.toEntity());
         return "redirect:/tasks";

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -6,10 +6,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.BindingResult;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 @Controller
 @RequiredArgsConstructor
@@ -38,20 +35,15 @@ public class TaskController {
 
     // GET /tasks/creationForm
     @GetMapping("/creationForm")
-    public String showCreationForm(TaskForm form, Model model)
-    {
-        if (form == null){
-            form = new TaskForm(null, null, null);
-        }
-        model.addAttribute("taskForm", form);
+    public String showCreationForm(@ModelAttribute TaskForm form) {
         return "tasks/form";
     }
     
     // POST /tasks
     @PostMapping
-    public String create(@Validated TaskForm form, BindingResult bindingResult, Model model) {
+    public String create(@Validated TaskForm form, BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
-            return showCreationForm(form, model);
+            return showCreationForm(form);
         }
         taskService.create(form.toEntity());
         return "redirect:/tasks";

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -42,9 +42,9 @@ public class TaskController {
     
     // POST /tasks
     @PostMapping("/tasks")
-    public String create(TaskForm form, Model model) {
+    public String create(TaskForm form) {
         var newEntity = new TaskEntity(null, form.summary(), form.description(), TaskStatus.valueOf(form.status()));
         taskService.create(newEntity);
-        return list(model);
+        return "redirect:/tasks";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 
 @Controller
 @RequiredArgsConstructor
@@ -35,5 +36,11 @@ public class TaskController {
     @GetMapping("/tasks/creationForm")
     public String showCreationForm() {
         return "tasks/form";
+    }
+    
+    // POST /tasks
+    @PostMapping("/tasks")
+    public String create(Model model) {
+        return list(model);
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -1,6 +1,8 @@
 package com.example.todo.controller.task;
 
+import com.example.todo.service.task.TaskEntity;
 import com.example.todo.service.task.TaskService;
+import com.example.todo.service.task.TaskStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
@@ -41,6 +43,8 @@ public class TaskController {
     // POST /tasks
     @PostMapping("/tasks")
     public String create(TaskForm form, Model model) {
+        var newEntity = new TaskEntity(null, form.summary(), form.description(), TaskStatus.valueOf(form.status()));
+        taskService.create(newEntity);
         return list(model);
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -2,10 +2,13 @@ package com.example.todo.controller.task;
 
 import com.example.todo.service.task.TaskEntity;
 import com.example.todo.service.task.TaskStatus;
+import jakarta.validation.constraints.NotBlank;
 
 public record TaskForm(
+    @NotBlank
     String summary,
     String description,
+    @NotBlank
     String status
 ) {
     public TaskEntity toEntity() {

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -3,6 +3,7 @@ package com.example.todo.controller.task;
 import com.example.todo.service.task.TaskEntity;
 import com.example.todo.service.task.TaskStatus;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
 import jakarta.validation.constraints.Size;
 
 public record TaskForm(
@@ -11,6 +12,7 @@ public record TaskForm(
     String summary,
     String description,
     @NotBlank
+    @Pattern(regexp="TODO|DOING|DONE", message = "Todo, Doing, Done のいずれかを選択してください")
     String status
 ) {
     public TaskEntity toEntity() {

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -1,0 +1,8 @@
+package com.example.todo.controller.task;
+
+public record TaskForm(
+    String summary,
+    String description,
+    String status
+) {
+}

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -3,9 +3,11 @@ package com.example.todo.controller.task;
 import com.example.todo.service.task.TaskEntity;
 import com.example.todo.service.task.TaskStatus;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
 
 public record TaskForm(
     @NotBlank
+    @Size(max = 256, message = "256文字以内で入力してください")
     String summary,
     String description,
     @NotBlank

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -1,8 +1,14 @@
 package com.example.todo.controller.task;
 
+import com.example.todo.service.task.TaskEntity;
+import com.example.todo.service.task.TaskStatus;
+
 public record TaskForm(
     String summary,
     String description,
     String status
 ) {
+    public TaskEntity toEntity() {
+        return new TaskEntity(null, summary(), description(), TaskStatus.valueOf(status()));
+    }
 }

--- a/src/main/java/com/example/todo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/todo/repository/task/TaskRepository.java
@@ -1,6 +1,7 @@
 package com.example.todo.repository.task;
 
 import com.example.todo.service.task.TaskEntity;
+import org.apache.ibatis.annotations.Insert;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 import org.apache.ibatis.annotations.Select;
@@ -15,4 +16,10 @@ public interface TaskRepository {
 
     @Select("SELECT id, summary, description, status FROM tasks WHERE id = #{taskId}")
     Optional<TaskEntity> selectById(@Param("taskId") long taskId);
+
+    @Insert("""
+    INSERT INTO tasks (summary, description,status)
+    VALUES (#{task.summary}, #{task.description}, #{task.status})
+    """)
+    void insert(@Param("task") TaskEntity newEntity);
 }

--- a/src/main/java/com/example/todo/service/task/TaskEntity.java
+++ b/src/main/java/com/example/todo/service/task/TaskEntity.java
@@ -1,7 +1,7 @@
 package com.example.todo.service.task;
 
 public record TaskEntity(
-        long id,
+        Long id,
         String summary,
         String description,
         TaskStatus status

--- a/src/main/java/com/example/todo/service/task/TaskService.java
+++ b/src/main/java/com/example/todo/service/task/TaskService.java
@@ -20,4 +20,8 @@ public class TaskService {
     public Optional<TaskEntity> findById(long taskId) {
         return taskRepository.selectById(taskId);
     }
+
+    public void create(TaskEntity newEntity) {
+        taskRepository.insert(newEntity);
+    }
 }

--- a/src/main/java/com/example/todo/service/task/TaskService.java
+++ b/src/main/java/com/example/todo/service/task/TaskService.java
@@ -3,6 +3,7 @@ package com.example.todo.service.task;
 import com.example.todo.repository.task.TaskRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
@@ -21,6 +22,7 @@ public class TaskService {
         return taskRepository.selectById(taskId);
     }
 
+    @Transactional
     public void create(TaskEntity newEntity) {
         taskRepository.insert(newEntity);
     }

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -10,18 +10,18 @@
 <body>
 <section layout:fragment="content">
     <div>
-        <form th:action="@{/tasks}" method="post">
+        <form th:action="@{/tasks}" method="post" th:object="${taskForm}">
             <div>
                 <label for="summaryInput">概要</label>
-                <input type="text" id="summaryInput" name="summary">
+                <input type="text" id="summaryInput" th:field="*{summary}">
             </div>
             <div>
                 <label for="descriptionInput">詳細</label>
-                <textarea id="descriptionInput" name="description"></textarea>
+                <textarea id="descriptionInput" th:field="*{description}"></textarea>
             </div>
             <div>
                 <label for="statusInput">ステータス</label>
-                <select id="statusInput" name="status">
+                <select id="statusInput" th:field="*{status}">
                     <option value="TODO">TODO</option>
                     <option value="DOING">DOING</option>
                     <option value="DONE">DONE</option>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="ja"
+      xmlns:th="http://www.thymeleaf.org"
+      xmlns:layout="http://www.ultrag.net.nz/thymeleaf/layout"
+      layout:decorate="~{layout/layout}"
+>
+<head>
+    <title>タスク作成</title>
+</head>
+<body>
+<section layout:fragment="content">
+    <p>WIP:　タスク作成</p>
+</section>
+</body>
+</html>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -13,15 +13,15 @@
         <form th:action="@{/tasks}" method="post">
             <div>
                 <label for="summaryInput">概要</label>
-                <input type="text" id="summaryInput">
+                <input type="text" id="summaryInput" name="summary">
             </div>
             <div>
                 <label for="descriptionInput">詳細</label>
-                <textarea id="descriptionInput"></textarea>
+                <textarea id="descriptionInput" name="description"></textarea>
             </div>
             <div>
                 <label for="statusInput">ステータス</label>
-                <select id="statusInput">
+                <select id="statusInput" name="status">
                     <option value="TODO">TODO</option>
                     <option value="DOING">DOING</option>
                     <option value="DONE">DONE</option>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -33,6 +33,7 @@
             </div>
             <div class="mt-3">
                 <button tyoe="submit" class="btn btn-primary">作成</button>
+                <a th:href="@{/tasks}" class="btn btn-secondary">戻る</a>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -13,23 +13,23 @@
         <form th:action="@{/tasks}" method="post" th:object="${taskForm}">
             <div class="form-group mt-3">
                 <label for="summaryInput" class="form-label">概要</label>
-                <input type="text" id="summaryInput" th:field="*{summary}" class="form-control">
-                <span th:errors="*{summary}"></span>
+                <input type="text" id="summaryInput" th:field="*{summary}" class="form-control" th:errorclass="is-invalid">
+                <span th:errors="*{summary}" class="invalid-feedback"></span>
             </div>
             <div class="form-group mt-3">
                 <label for="descriptionInput" class="form-label">詳細</label>
-                <textarea id="descriptionInput" th:field="*{description}" class="form-control" rows="10"></textarea>
-                <span th:errors="*{description}"></span>
+                <textarea id="descriptionInput" th:field="*{description}" class="form-control" rows="10" th:errorclass="is-invalid"></textarea>
+                <span th:errors="*{description}" class="invalid-feedback"></span>
 
             </div>
             <div class="form-group mt-3">
                 <label for="statusInput" class="form-label">ステータス</label>
-                <select id="statusInput" th:field="*{status}" class="form-control">
+                <select id="statusInput" th:field="*{status}" class="form-control" th:errorclass="is-invalid">
                     <option value="TODO">TODO</option>
                     <option value="DOING">DOING</option>
                     <option value="DONE">DONE</option>
                 </select>
-                <span th:errors="*{status}"></span>
+                <span th:errors="*{status}" class="invalid-feedback"></span>
             </div>
             <div class="mt-3">
                 <button tyoe="submit" class="btn btn-primary">作成</button>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -14,10 +14,13 @@
             <div>
                 <label for="summaryInput">概要</label>
                 <input type="text" id="summaryInput" th:field="*{summary}">
+                <span th:errors="*{summary}"></span>
             </div>
             <div>
                 <label for="descriptionInput">詳細</label>
                 <textarea id="descriptionInput" th:field="*{description}"></textarea>
+                <span th:errors="*{description}"></span>
+
             </div>
             <div>
                 <label for="statusInput">ステータス</label>
@@ -26,6 +29,7 @@
                     <option value="DOING">DOING</option>
                     <option value="DONE">DONE</option>
                 </select>
+                <span th:errors="*{status}"></span>
             </div>
             <div>
                 <button tyoe="submit">作成</button>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -10,7 +10,7 @@
 <body>
 <section layout:fragment="content">
     <div>
-        <form>
+        <form th:action="@{/tasks}" method="post">
             <div>
                 <label for="summaryInput">概要</label>
                 <input type="text" id="summaryInput">

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -9,7 +9,29 @@
 </head>
 <body>
 <section layout:fragment="content">
-    <p>WIP:　タスク作成</p>
+    <div>
+        <form>
+            <div>
+                <label for="summaryInput">概要</label>
+                <input type="text" id="summaryInput">
+            </div>
+            <div>
+                <label for="descriptionInput">詳細</label>
+                <textarea id="descriptionInput"></textarea>
+            </div>
+            <div>
+                <label for="statusInput">ステータス</label>
+                <select id="statusInput">
+                    <option value="TODO">TODO</option>
+                    <option value="DOING">DOING</option>
+                    <option value="DONE">DONE</option>
+                </select>
+            </div>
+            <div>
+                <button tyoe="submit">作成</button>
+            </div>
+        </form>
+    </div>
 </section>
 </body>
 </html>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -11,28 +11,28 @@
 <section layout:fragment="content">
     <div>
         <form th:action="@{/tasks}" method="post" th:object="${taskForm}">
-            <div>
-                <label for="summaryInput">概要</label>
-                <input type="text" id="summaryInput" th:field="*{summary}">
+            <div class="form-group mt-3">
+                <label for="summaryInput" class="form-label">概要</label>
+                <input type="text" id="summaryInput" th:field="*{summary}" class="form-control">
                 <span th:errors="*{summary}"></span>
             </div>
-            <div>
-                <label for="descriptionInput">詳細</label>
-                <textarea id="descriptionInput" th:field="*{description}"></textarea>
+            <div class="form-group mt-3">
+                <label for="descriptionInput" class="form-label">詳細</label>
+                <textarea id="descriptionInput" th:field="*{description}" class="form-control" rows="10"></textarea>
                 <span th:errors="*{description}"></span>
 
             </div>
-            <div>
-                <label for="statusInput">ステータス</label>
-                <select id="statusInput" th:field="*{status}">
+            <div class="form-group mt-3">
+                <label for="statusInput" class="form-label">ステータス</label>
+                <select id="statusInput" th:field="*{status}" class="form-control">
                     <option value="TODO">TODO</option>
                     <option value="DOING">DOING</option>
                     <option value="DONE">DONE</option>
                 </select>
                 <span th:errors="*{status}"></span>
             </div>
-            <div>
-                <button tyoe="submit">作成</button>
+            <div class="mt-3">
+                <button tyoe="submit" class="btn btn-primary">作成</button>
             </div>
         </form>
     </div>

--- a/src/main/resources/templates/tasks/list.html
+++ b/src/main/resources/templates/tasks/list.html
@@ -10,7 +10,10 @@
 <body>
 <section layout:fragment="content">
     <div>
-        <table>
+        <a th:href="@{tasks/creationForm}" class="btn btn-primary">作成</a>
+    </div>
+    <div>
+        <table class="table">
             <thead>
             <tr>
                 <th>ID</th>


### PR DESCRIPTION
- 68
    - タスク作成画面(form.html)の作成と、TaskControllerにハンドラーメソッド(showCreationForm)を追加
- 69　タスク作成画面で入力フォームの作成
    - formタグで入力フォームの作成
→`<input>`で一行のテキストボックスを設置
→`<textarea>`で複数行のテキストボックスの設置
→`<select>`でセレクトボックスの設置
→`<button>`内に`type="submit"`を入れることでPOSTされるようにし、作成ボタンの設置
- 70　タスク一覧画面にタスク作成画面のリンクを設置
    - `<a>`内に`th:href="@{~}"`でリンクを指定し、`class="btn btn-primary"`でボタンのクラス要素を追加
- 71　formの作成ボタンを押下したときに処理を担当するハンドラーメソッドの作成
    - formのPOST先の設定
→`<form>`に`th:action="@{/tasks}"`、`method="post"`とそれぞれ属性の追加をし、`POST /tasks`にformの内容を送るようにする
    - ハンドラーメソッドの作成
→`@PostMapping(/tasks)`でformの内容を受け取れるようにアノテーションの追加
- 72　formの内容をサーバに送信し、サーバ側で内容を受け取れるように設定
    - formの内容をサーバに送信するように設定
→formの入力要素にそれぞれname属性を追加し、それぞれnameで設定したキーで
　　　サーバにデータが送信されるように設定
    - ハンドラーメソッドの編集
→TaskFormクラスを作成し、POSTの内容をTaskControllerのcreateメソッドでformオブジェクトとしてまとめて受け取れるようにする
- 73　ユーザが入力した値をデータベースに保存する処理の追記

    - TaskController.createメソッド内でformオブジェクトから下記引数でTaskEntityに変換する
        - idはデータベースのオートインクリメントで発番されるためここではnullとする
→TaskEntityクラスのidはプリミティブ型なのでオブジェクトのLongにし、nullでエラーが発生しないようにする
        - summaryとdescriptionは`form.summary()`のようにする
        - statusは文字列からenumクラスに変換するため、`TaskStatu.valueof(form.status())`のようにして一度型変換する
    - TaskServiceにcreateメソッドを作成し、このメソッドが呼び出されればデータの保存ができるようにする
        - TaskRepositryでデータを保存するinsertメソッドの追加
        - TaskRepositry.createでTaskReopositry.insertメソッドを呼び出し
- 74　作成処理にトランザクションの追加
    - TaskController.createに@Transactionalアノテーションを追加し、メソッド内でエラーが発生した場合はロールバックするように修正
- 75　PRGパターンの説明
    - POSTリクエストが発行された後に、GETリクエストを発行することでリロードボタンを押したときにリクエストが再送信されるのだが、POSTではなくGETで送られるため、POSTの多重送信を避けることができる
    -  意図しないPOSTリクエストの再送信はリロードボタンをクリック時に発生するそれを回けるするためにPRGパターンがある
- 76　2重サブミット対策(上記75の実践)
    - TaskController.createのreturnを`redirect: /tasks`に修正
- 77　TaskController.createのコードをリファクタリング
    - `form.toEntity()`でTaskEntityに変換できるように、TaskForm.toEntityを追加し戻り値をTaskEntityにする
    - TaskEntityを作成するメソッドをTaskFormのインスタンスメソッドとして定義
- 78　@RequestMppingアノテーションを活用してGetMappingやPostMappingの
　　パスの記述を削除、省略
- 79　概要とステータス項目は必須項目なためバリデーションの追加
    - TaskFormのsummaryとstatusのクラスに@NotBlankとアノテーションをつけ、nullの場合にエラーが発生するようにする
    - 上記バリデーションを実行するため、TaskController.createの引数TaskFormの前に@validatedとアノテーションをつける
    - 引数にBindingResultクラスを追加し、`bindingResult.hasError()`によってエラー時に分岐させる処理の追加
- 80　エラー時にフォームの内容を保持したままにする
    - エラー時にタスク作成画面のハンドラーメソッド(showCreationForm)を呼び出す
→入力した値(TaskForm)をshowCreationFormからformに渡すために
    - 引数にTaskFormとModelを追加し、addAttributeでtaskFormという変数を定義
→formの`<form>`内に`th:field`を追加し、taskFormの内容がそれぞれの入力要素に代入されるように修正
- 81　@ModelAttributeアノテーションによるコードリファクタリング
    -  メソッドの引数に@ModelAttributeを追加することで`modal.addAttribute`と同じように画面に値を渡せるようになる
→キー名を指定しない場合は引数のクラス名(先頭が小文字になる)がキー名になる
    - 引数の中身がnullの場合自動で初期化される
- 82　バリデーションメッセージの表示
    - `<span>`を追加し、`th:errors`の属性を追加する
- 83　最大長のバリデーションの追加
    - TaskFormクラスの属性に@Sizeアノテーションで追加する
→maxで最大、messageでエラーメッセージの変更ができる
- 84　ステータスに入力できる文字のバリデーション追加
    - TaskFormクラスの属性に@Patternアノテーションで追加する
→regexpで指定したものでなければエラーを返せる
- 85
    - formでそれぞれの入力タグにクラスなどを指定してスタイリングの調整
- 86
    - `<span>`にクラスを追加してバリデーションメッセージを赤く変更
- 87
    - `<a>`でformに戻るボタンの追加