### PR TITLE
10章分の追加

### DIFF
--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -36,15 +36,16 @@ public class TaskController {
 
     // GET /tasks/creationForm
     @GetMapping("/creationForm")
-    public String showCreationForm(@ModelAttribute TaskForm form) {
+    public String showCreationForm(@ModelAttribute TaskForm form, Model model) {
+        model.addAttribute("mode", "CREATE");
         return "tasks/form";
     }
     
     // POST /tasks
     @PostMapping
-    public String create(@Validated TaskForm form, BindingResult bindingResult) {
+    public String create(@Validated TaskForm form, BindingResult bindingResult, Model model) {
         if (bindingResult.hasErrors()) {
-            return showCreationForm(form);
+            return showCreationForm(form, model);
         }
         taskService.create(form.toEntity());
         return "redirect:/tasks";
@@ -57,6 +58,7 @@ public class TaskController {
                 .map(TaskForm::formEntity)
                 .orElseThrow(TaskNotFoundException::new);
         model.addAttribute("taskForm", form);
+        model.addAttribute("mode", "EDIT");
         return "tasks/form";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -48,4 +48,12 @@ public class TaskController {
         taskService.create(form.toEntity());
         return "redirect:/tasks";
     }
+    
+    // GET /tasks/{taskId}/editForm
+    @GetMapping("/{id}/editForm")
+    public String showEditForm(@PathVariable("id") long id, Model model) {
+        TaskForm form = new TaskForm("hoge", "hoge", "TODO");
+        model.addAttribute("taskForm", form);
+        return "tasks/form";
+    }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -73,6 +73,8 @@ public class TaskController {
             model.addAttribute("mode", "EDIT");
             return "tasks/form";
         }
+        var entity = form.toEntity(id);
+        taskService.update(entity);
         return "redirect:/tasks/{id}";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -61,4 +61,9 @@ public class TaskController {
         model.addAttribute("mode", "EDIT");
         return "tasks/form";
     }
+    
+    @PutMapping("{id}") // PUT /tasks/{id}
+    public String update(@PathVariable("id") long id ){
+        return "redirect:/tasks/{id}";
+    }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -28,7 +28,7 @@ public class TaskController {
     @GetMapping("/{id}") // GET /tasks/detail
     public String showDetail(@PathVariable("id") long taskId, Model model){
         var taskEntity = taskService.findById(taskId)
-                .orElseThrow(() -> new IllegalArgumentException("Task not found: id = " + taskId));
+                .orElseThrow(TaskNotFoundException::new);
         model.addAttribute("task", TaskDTO.toDTO(taskEntity));
         return "tasks/detail";
     }
@@ -53,7 +53,7 @@ public class TaskController {
     @GetMapping("/{id}/editForm")
     public String showEditForm(@PathVariable("id") long id, Model model) {
         var taskEntity = taskService.findById(id)
-                .orElseThrow(() -> new IllegalArgumentException("Task not found"));
+                .orElseThrow(TaskNotFoundException::new);
         var form = new TaskForm(taskEntity.summary(), taskEntity.description(), taskEntity.status().name());
         model.addAttribute("taskForm", form);
         return "tasks/form";

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -27,9 +27,10 @@ public class TaskController {
 
     @GetMapping("/{id}") // GET /tasks/detail
     public String showDetail(@PathVariable("id") long taskId, Model model){
-        var taskEntity = taskService.findById(taskId)
+        var taskDTO = taskService.findById(taskId)
+            .map(TaskDTO::toDTO)
                 .orElseThrow(TaskNotFoundException::new);
-        model.addAttribute("task", TaskDTO.toDTO(taskEntity));
+        model.addAttribute("task", taskDTO);
         return "tasks/detail";
     }
 
@@ -52,9 +53,9 @@ public class TaskController {
     // GET /tasks/{taskId}/editForm
     @GetMapping("/{id}/editForm")
     public String showEditForm(@PathVariable("id") long id, Model model) {
-        var taskEntity = taskService.findById(id)
+        var form = taskService.findById(id)
+                .map(TaskForm::formEntity)
                 .orElseThrow(TaskNotFoundException::new);
-        var form = new TaskForm(taskEntity.summary(), taskEntity.description(), taskEntity.status().name());
         model.addAttribute("taskForm", form);
         return "tasks/form";
     }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -52,7 +52,9 @@ public class TaskController {
     // GET /tasks/{taskId}/editForm
     @GetMapping("/{id}/editForm")
     public String showEditForm(@PathVariable("id") long id, Model model) {
-        TaskForm form = new TaskForm("hoge", "hoge", "TODO");
+        var taskEntity = taskService.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("Task not found"));
+        var form = new TaskForm(taskEntity.summary(), taskEntity.description(), taskEntity.status().name());
         model.addAttribute("taskForm", form);
         return "tasks/form";
     }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -63,7 +63,16 @@ public class TaskController {
     }
     
     @PutMapping("{id}") // PUT /tasks/{id}
-    public String update(@PathVariable("id") long id ){
+    public String update(
+        @PathVariable("id") long id,
+        @Validated @ModelAttribute TaskForm form,
+        BindingResult bindingResult,
+        Model model
+    ){
+        if (bindingResult.hasErrors()){
+            model.addAttribute("mode", "EDIT");
+            return "tasks/form";
+        }
         return "redirect:/tasks/{id}";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -26,4 +26,8 @@ public record TaskForm(
     public TaskEntity toEntity() {
         return new TaskEntity(null, summary(), description(), TaskStatus.valueOf(status()));
     }
+
+    public TaskEntity toEntity(long id) {
+        return new TaskEntity(id, summary(), description(), TaskStatus.valueOf(status()));
+    }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskForm.java
+++ b/src/main/java/com/example/todo/controller/task/TaskForm.java
@@ -15,6 +15,14 @@ public record TaskForm(
     @Pattern(regexp="TODO|DOING|DONE", message = "Todo, Doing, Done のいずれかを選択してください")
     String status
 ) {
+    public static TaskForm formEntity(TaskEntity taskEntity) {
+        return new TaskForm(
+            taskEntity.summary(),
+            taskEntity.description(),
+            taskEntity.status().name()
+        );
+    }
+
     public TaskEntity toEntity() {
         return new TaskEntity(null, summary(), description(), TaskStatus.valueOf(status()));
     }

--- a/src/main/java/com/example/todo/controller/task/TaskNotFoundException.java
+++ b/src/main/java/com/example/todo/controller/task/TaskNotFoundException.java
@@ -1,0 +1,8 @@
+package com.example.todo.controller.task;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class TaskNotFoundException extends RuntimeException {
+}

--- a/src/main/java/com/example/todo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/todo/repository/task/TaskRepository.java
@@ -1,10 +1,7 @@
 package com.example.todo.repository.task;
 
 import com.example.todo.service.task.TaskEntity;
-import org.apache.ibatis.annotations.Insert;
-import org.apache.ibatis.annotations.Mapper;
-import org.apache.ibatis.annotations.Param;
-import org.apache.ibatis.annotations.Select;
+import org.apache.ibatis.annotations.*;
 
 import java.util.List;
 import java.util.Optional;
@@ -18,8 +15,19 @@ public interface TaskRepository {
     Optional<TaskEntity> selectById(@Param("taskId") long taskId);
 
     @Insert("""
-    INSERT INTO tasks (summary, description,status)
-    VALUES (#{task.summary}, #{task.description}, #{task.status})
-    """)
+            INSERT INTO tasks (summary, description,status)
+            VALUES (#{task.summary}, #{task.description}, #{task.status})
+            """)
     void insert(@Param("task") TaskEntity newEntity);
+
+    @Update("""
+            UPDATE tasks
+            SET
+              summary     = #{task.summary},
+              description = #{task.description},
+              status      = #{task.status}
+            WHERE
+              id = #{task.id}
+            """)
+    void update(@Param("task") TaskEntity entity);
 }

--- a/src/main/java/com/example/todo/service/task/TaskService.java
+++ b/src/main/java/com/example/todo/service/task/TaskService.java
@@ -26,4 +26,9 @@ public class TaskService {
     public void create(TaskEntity newEntity) {
         taskRepository.insert(newEntity);
     }
+
+    @Transactional
+    public void update(TaskEntity entity) {
+        taskRepository.update(entity);
+    }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -5,3 +5,4 @@ spring.datasource.url=jdbc:h2:mem:todo
 spring.datasource.username=sa
 spring.datasource.password=
 logging.level.com.example.todo.repository=DEBUG
+spring.mvc.hiddenmethod.filter.enabled=true

--- a/src/main/resources/templates/tasks/detail.html
+++ b/src/main/resources/templates/tasks/detail.html
@@ -9,7 +9,10 @@
 </head>
 <body>
 <section layout:fragment="content">
-    <div th:object="${task}">
+    <div >
+        <a th:href="@{/tasks/{id}/editForm(id=${id})}" class="btn btn-primary">編集</a>
+    </div>
+    <div th:object="${task}" class="mt-3">
         <h2 th:text="'#' + *{id} + ' ' + *{summary}"></h2>
         <p th:text="*{status}"></p>
         <pre th:text="*{description}"></pre>

--- a/src/main/resources/templates/tasks/form.html
+++ b/src/main/resources/templates/tasks/form.html
@@ -5,12 +5,14 @@
       layout:decorate="~{layout/layout}"
 >
 <head>
-    <title>タスク作成</title>
+    <title th:text="${mode == 'CREATE'} ? 'タスク作成' : 'タスク編集'"></title>
 </head>
 <body>
 <section layout:fragment="content">
     <div>
-        <form th:action="@{/tasks}" method="post" th:object="${taskForm}">
+        <form th:action="${mode == 'CREATE'} ? @{/tasks} : @{/tasks/{id}(id=${id})}"
+              th:method="${mode == 'CREATE'} ? post : put"
+              th:object="${taskForm}">
             <div class="form-group mt-3">
                 <label for="summaryInput" class="form-label">概要</label>
                 <input type="text" id="summaryInput" th:field="*{summary}" class="form-control" th:errorclass="is-invalid">
@@ -32,8 +34,8 @@
                 <span th:errors="*{status}" class="invalid-feedback"></span>
             </div>
             <div class="mt-3">
-                <button tyoe="submit" class="btn btn-primary">作成</button>
-                <a th:href="@{/tasks}" class="btn btn-secondary">戻る</a>
+                <button type="submit" class="btn btn-primary" th:text="${mode == 'CREATE'} ? 作成 : 編集"></button>
+                <a th:href="${mode == 'CREATE'} ? @{/tasks} : @{/tasks/{id}(id=${id})}" class="btn btn-secondary">戻る</a>
             </div>
         </form>
     </div>


### PR DESCRIPTION
- 88
    - タスク編集ページのハンドラーメソッド(TaskController.showEditForm)の作成
- 89
    - タスク詳細ページにタスク編集ボタンの追加
- 90
    - タスク編集ページのフォームにデータベースに保存されている値の表示方法
        - `taskService.findById(id)`でデータベースの値を取ってくる 
        - 値がEntityクラスなので、Formクラスに変換する
→`TaskForm(taskEntity.summary(), ~~)`のように記述
        - addAttributeで値をタスク編集ページに渡す
- 91
    - 存在しないタスクIDの編集ページが呼ばれた場合500系のエラーが表示されてしまうので400系が表示されるように修正
        - TaskNotFoundと、独自の例外クラスを作成
→RuntimeExceptionのクラスを継承することで、そのクラスを例外のクラスとすることができる
        - @ResponceStatusアノテーションをつけることで例外クラスが呼ばれた際にクライアントへのレスポンスステータスを設定できる
→`@ResponceStatus(HttpStatus.NotFound)`とすれば400系の例外を発生できる
- 92
    - entityをformに変換するコードのリファクタリング
        - entityからformに変換するコードをメソッドにしてTaskFormのファイルに置く
        - mapでentityを受け取って上記メソッドを呼び出してOptionalの中身を変換する
→ラムダ化してさらに記述を省略化
- 93
    - タスク編集画面のタイトルやボタン、遷移先の変更
        - それぞれのタグ内に三項演算子を入れて編集画面と作成画面で表示や遷移先、出力方法を分岐させる
→`${mode == 'CREATE'} ? 'タスク作成' : 'タスク編集'`のようにmode変数に入っている値で出力内容を変化させる
        - 作成画面、編集画面のハンドラーメソッドにそれぞれ`addAttribute`でmodeに変数を代入する(作成画面はCREATE、編集画面はEDIT)
- 94
    - 編集のリクエストを受け取るハンドラーメソッドの作成
        - putのリクエストを受け取るために@PutMappingのアノテーションをつけたメソッドの作成
- 95
    - 編集のリクエストが飛んできたときにバリデーションをかけるためにハンドラーメソッドの修正
        - 引数のTaskFormに@Validatedをつけ、BindingResultを引数に追加してエラーの発生をメソッド内で検知できるようにする
            - if文で`bindingResult.hasErrors()`がtrueのときformに戻すように追記
            - addAttributeでmodeにEDITを代入して編集画面を表出させる
        - TaskFormに@ModelAttributeをつけ、エラー発生時にformの内容が飛ばないようにする
- 96
    - 変更内容をデータベースに保存させる処理の記述
        - toEntityメソッドでformをentityに変換させる
        - データベースに変更を保存させるTaskService.updateメソッドの作成
            - @Transactionalアノテーションを追加してエラー時にロールバックさせるようにする
            - SQLでデータベースを変更させるtaskRepositoryメソッドの作成
→SQLでUPDATEを使うため@Updateアノテーションを追加しUPDATE文の追記
→UPDATE文内でentityの内容を使うために@Paramアノテーションで変数を引数で設定する



