### PR TITLE
11章分の追加

### DIFF
--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -82,6 +82,7 @@ public class TaskController {
     // -> DELETE /tasks/1
     @DeleteMapping("{id}")
     public String delete(@PathVariable("id") long id) {
+        taskService.delete(id);
         return "redirect:/tasks";
     }
 }

--- a/src/main/java/com/example/todo/controller/task/TaskController.java
+++ b/src/main/java/com/example/todo/controller/task/TaskController.java
@@ -77,4 +77,11 @@ public class TaskController {
         taskService.update(entity);
         return "redirect:/tasks/{id}";
     }
+
+    // POST /tasks/1 (hidden: _method: delete)
+    // -> DELETE /tasks/1
+    @DeleteMapping("{id}")
+    public String delete(@PathVariable("id") long id) {
+        return "redirect:/tasks";
+    }
 }

--- a/src/main/java/com/example/todo/repository/task/TaskRepository.java
+++ b/src/main/java/com/example/todo/repository/task/TaskRepository.java
@@ -30,4 +30,7 @@ public interface TaskRepository {
               id = #{task.id}
             """)
     void update(@Param("task") TaskEntity entity);
+
+    @Delete("DELETE FROM tasks WHERE id = #{taskId}")
+    void delete(@Param("taskId") long id);
 }

--- a/src/main/java/com/example/todo/service/task/TaskService.java
+++ b/src/main/java/com/example/todo/service/task/TaskService.java
@@ -31,4 +31,9 @@ public class TaskService {
     public void update(TaskEntity entity) {
         taskRepository.update(entity);
     }
+
+    @Transactional
+    public void delete(long id) {
+        taskRepository.delete(id);
+    }
 }

--- a/src/main/resources/templates/tasks/detail.html
+++ b/src/main/resources/templates/tasks/detail.html
@@ -11,7 +11,12 @@
 <section layout:fragment="content">
     <div>
         <a th:href="@{/tasks/{id}/editForm(id=${id})}" class="btn btn-primary">編集</a>
-        <form th:action="@{/tasks/{id}(id=${id})}" th:method="delete" style="display: inline;">
+        <form
+                th:action="@{/tasks/{id}(id=${id})}"
+                th:method="delete"
+                style="display: inline;"
+                onclick="return confirm('タスクを削除しますか？');"
+        >
             <button type="submit" class="btn btn-danger">削除</button>
         </form>
 

--- a/src/main/resources/templates/tasks/detail.html
+++ b/src/main/resources/templates/tasks/detail.html
@@ -9,8 +9,12 @@
 </head>
 <body>
 <section layout:fragment="content">
-    <div >
+    <div>
         <a th:href="@{/tasks/{id}/editForm(id=${id})}" class="btn btn-primary">編集</a>
+        <form th:action="@{/tasks/{id}(id=${id})}" th:method="delete" style="display: inline;">
+            <button type="submit" class="btn btn-danger">削除</button>
+        </form>
+
     </div>
     <div th:object="${task}" class="mt-3">
         <h2 th:text="'#' + *{id} + ' ' + *{summary}"></h2>


### PR DESCRIPTION
- 97
    - 削除ボタンの実装
        - `th:method="delete"`でDELETEのリクエストが飛ぶように実装
→`hidden _method: delete`を上記で省略できる
- 98
    - 削除処理を担当するハンドラーメソッドの実装
        - `@DeleteMapping({id})`でdeleteのメソッドが入ったPOSTを受け入れる
- 99
    - 削除機能の実装
        - taskService.deleteを作成し、このメソッドが呼び出された場合にデータの削除をするようにする
→taskRepositryでデータを削除するdeleteメソッドの追加
→TaskService.deleteでtaskRepositry.deleteの呼び出し
→TaskService.deleteに@Transactionalアノテーションを追加してエラー発生時にロールバックするようにする
- 100
    - 削除ボタンを押した際に確認ダイアログを出力するようにする
        - 削除ボタンの`<form>`内に`onclick="return confirm('~')"`を追加し、メッセージを記述する